### PR TITLE
throw an error if the facilitator has made a mistake

### DIFF
--- a/R/fitdist.R
+++ b/R/fitdist.R
@@ -163,10 +163,10 @@ fitdist <-
       
       # Need to exclude any probability judgements
       # P(X<=x) = 0 or P(X<=x) = 1
-      # Facilitator should enforce these probabilities via the parameter limits
+      # Facilitator should enforce these probabilities via the parameter limits  
       
       inc <- (probs[, i] > 0) & (probs[, i] < 1)
-      
+      if(sum(inc) < 1){stop("need at least one probability between 0 and 1")}
       minprob <- min(probs[inc, i])
       maxprob <- max(probs[inc, i])
       minvals <- min(vals[inc, i])


### PR DESCRIPTION
Throw an informative error, if (the facilitator has made a mistake and allowed) probs not have any values between 0 and 1, eg all chips in one bin, indicating no uncertainty. Currently it throws `min(probs[inc, i]): no non-missing arguments to min; returning Inf`



I
![Screenshot 2024-05-15 at 16 15 35](https://github.com/OakleyJ/SHELF/assets/22461396/af301431-ffb6-41c4-9219-39554246d4ff)
